### PR TITLE
Feature/add search session as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `vtex.search-session` as dependency.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # search-segment-resolver
+
+The `vtex.search-segment-resolver` is a boilerplate that you can use for you own implementation of the segment search (TODO: add the segment documentation link).
+
+## Usage
+
+1.  Fork this project.
+2.  Change the `vendor` in the `manifest.json` file.
+3.  Change the `searchSegment` function in the `/node/resolver/segmentSearch.ts` file. It will receive the `userEmail` as argument and must return an array of facets. Exanoke:
+
+    ```javascript
+    export const queries = {
+        searchSegment: async (_: unknown, args: SearchSegmentInput, __: Context) => {
+            const { userEmail } = args
+
+            switch (userEmail) {
+            case 'myclient@shoes.com':
+                return [{ key: 'category-1', value: 'shoes' }]
+
+            case 'myclient@shirts.com':
+                return [{ key: 'category-1', value: 'shirt' }]
+
+            case 'myclient@hats.com':
+                return [{ key: 'category-1', value: 'hats' }]
+
+            default:
+                return []
+            }
+        },
+    }
+    ```
+    3.5 If you want to call an external API, you can add a new client to the `node/clients` diredtory.
+4. Link/install the app on your workspace.

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "vtex.messages": "1.x",
     "vtex.search-segment-graphql": "0.x",
-    "vtex.store-graphql": "2.x"
+    "vtex.store-graphql": "2.x",
+    "vtex.search-session": "0.x"
   },
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `vtex.search-session` as a dependency. This way, the client doesn't need to manually install it.

I also added a brief usage guide on the README.md. Once the [recipe](https://github.com/vtex-apps/io-documentation/pull/1082) is published, I will add the link to it in the README
